### PR TITLE
Table scrollbar visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
     .toggle.danger input:checked + .dot::after{background:#fff}
     .toggle.danger.active{border-color:rgba(217,45,32,.55); color:var(--danger)}
 
-    .card{background:var(--card); border:1px solid var(--line); border-radius:16px; overflow:auto;}
+    .card{background:var(--card); border:1px solid var(--line); border-radius:16px; overflow-x:auto; overflow-y:hidden;}
     table{width:100%; border-collapse:collapse;}
     th,td{padding:10px 12px; border-bottom:1px solid var(--line); font-size:13px; vertical-align:top}
     th{color:var(--muted); text-align:left; font-weight:600;}


### PR DESCRIPTION
Hide unnecessary vertical scrollbars in the table container to prevent them from appearing when the table has few rows.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e0e5f40-f9b6-4079-b77f-1ef4842f6416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7e0e5f40-f9b6-4079-b77f-1ef4842f6416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

