### PR TITLE
Sydney wind gust data

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,9 @@
     { name: "Horseshoe Lagoon", state: "NSW", searchTerm: "Horseshoe Lagoon" },
     { name: "Jindabyne", state: "NSW", searchTerm: "Jindabyne" },
     { name: "Lake Hume, NSW", state: "NSW", searchTerm: "Lake Hume" },
-    { name: "Lane Cove", state: "NSW", searchTerm: "Sydney" },
+    // "Sydney" often maps to Observatory Hill, whose observations frequently report gust as null.
+    // "Mascot" maps to Sydney Airport, which reliably provides gust observations + hourly gust forecasts.
+    { name: "Lane Cove", state: "NSW", searchTerm: "Mascot" },
     { name: "Maidens Inn, Moama", state: "NSW", searchTerm: "Moama" },
     { name: "Moama Waters", state: "NSW", searchTerm: "Moama" },
     { name: "Moama West", state: "NSW", searchTerm: "Moama" },


### PR DESCRIPTION
Fix missing wind/gust data for Sydney by changing its BOM search term to 'Mascot'.

The original "Sydney" search term often mapped to Observatory Hill, which frequently reported `gust: null`. Changing the search term to "Mascot" maps to Sydney Airport, which reliably provides gust observations and hourly gust forecasts, ensuring the data is displayed as expected.

---
<a href="https://cursor.com/background-agent?bcId=bc-231799b1-5ffe-4fe8-8531-a4568c7c7f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-231799b1-5ffe-4fe8-8531-a4568c7c7f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

