### PR TITLE
Wind table time offset

### DIFF
--- a/index.html
+++ b/index.html
@@ -663,17 +663,37 @@
   }
 
   function formatHourLabelMs(ms, timeZone){
-    // "10am" / "12pm" in the desired timezone
+    // "10am" / "12pm" / "9:30am" in the desired timezone
     try {
-      const s = new Intl.DateTimeFormat('en-AU', { hour: 'numeric', hour12: true, timeZone }).format(new Date(ms));
-      return String(s).replace(/\s+/g,'').toLowerCase();
+      const parts = new Intl.DateTimeFormat('en-AU', {
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+        timeZone
+      }).formatToParts(new Date(ms));
+
+      const get = (type) => parts.find(p => p.type === type)?.value ?? '';
+      const hour = get('hour');
+      const minute = get('minute'); // "00" or "30" (etc)
+      const dayPeriod = get('dayPeriod'); // "AM"/"PM"
+
+      let out = String(hour || '').trim();
+      if (minute && minute !== '00') out += `:${minute}`;
+      out += String(dayPeriod || '').trim();
+
+      return out
+        .replace(/\s+/g, '')
+        .replaceAll('.', '')
+        .toLowerCase();
     } catch {
       // Fallback: local time
       const d = new Date(ms);
+      const m = d.getMinutes();
       let h = d.getHours();
       const suffix = h >= 12 ? 'pm' : 'am';
       h = h % 12;
       if (h === 0) h = 12;
+      if (m && m !== 0) return `${h}:${String(m).padStart(2,'0')}${suffix}`;
       return `${h}${suffix}`;
     }
   }
@@ -1328,6 +1348,8 @@ async function bomForecastHourly(geohash){
       try {
         const ms = Date.parse('2026-01-22T01:00:00Z'); // should be 12pm in Sydney
         assert('formatHourLabelMs Sydney DST', formatHourLabelMs(ms, 'Australia/Sydney') === '12pm');
+        const ms2 = Date.parse('2026-01-22T00:00:00Z'); // should be 10:30am in Adelaide (ACDT = UTC+10:30)
+        assert('formatHourLabelMs Adelaide half-hour', formatHourLabelMs(ms2, 'Australia/Adelaide') === '10:30am');
       } catch {}
 
       allRows = [


### PR DESCRIPTION
Align wind table forecast columns to UTC and format labels by state timezone to fix the 1-hour time offset.

BOM hourly forecast timestamps are UTC (`...Z`), but the previous logic for generating column headers used the viewer's local clock. This caused a consistent 1-hour mismatch (e.g., BOM 12pm showing as 11am) when the viewer's timezone or DST rules differed from the park's location. This change ensures columns align with BOM's UTC times and labels correctly reflect the park's local time, including DST.

---
<a href="https://cursor.com/background-agent?bcId=bc-30629c96-bcdd-4aa7-951a-8471c7c48e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-30629c96-bcdd-4aa7-951a-8471c7c48e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

