### PR TITLE
Initial filter state

### DIFF
--- a/index.html
+++ b/index.html
@@ -1447,6 +1447,7 @@ async function bomForecastHourly(geohash){
         {state:'SA', name:'C', loaded:true, severity:'ok', gustKmh:10, hourlyGusts:new Map(), stationName:null},
       ];
       els.stateFilter.value = 'SA';
+      els.regionFilter.value = 'ALL';
       els.textFilter.value = '';
 
       showWarningParks = false; showDangerParks = false;


### PR DESCRIPTION
Reset region filter to 'ALL' in `runSelfTests` to prevent self-test failures due to saved user preferences.

The self-test was failing with "Self-test failed: filter off shows all" because it was running with a potentially active `regionFilter` from user preferences. Since the test data doesn't have region properties, an active filter would cause all test rows to be excluded, leading to an incorrect `filteredRows().length` of 0. Explicitly setting `els.regionFilter.value = 'ALL'` ensures the test runs in a clean, unfiltered state.

---
<a href="https://cursor.com/background-agent?bcId=bc-95825f87-fc23-4d66-add8-e497f2db959f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-95825f87-fc23-4d66-add8-e497f2db959f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

