### PR TITLE
Api forecast warnings

### DIFF
--- a/bom-proxy
+++ b/bom-proxy
@@ -28,13 +28,15 @@ export default {
     const isObs = /^\/v1\/locations\/[a-z0-9]+\/observations$/i.test(path);
     const isF3 = /^\/v1\/locations\/[a-z0-9]+\/forecasts\/3-hourly$/i.test(path);
     const isHourly = /^\/v1\/locations\/[a-z0-9]+\/forecasts\/hourly$/i.test(path);
+    const isWarnings = /^\/v1\/warnings\/?$/i.test(path);
+    const isWarningDetail = /^\/v1\/warnings\/[a-z0-9]+\/?$/i.test(path);
 
-    if (!isLocations && !isObs && !isF3 && !isHourly) {
+    if (!isLocations && !isObs && !isF3 && !isHourly && !isWarnings && !isWarningDetail) {
       return new Response("Forbidden path", { status: 403, headers: cors() });
     }
 
-    // /v1/locations doesn’t have the same geohash weirdness
-    if (isLocations) return await upstream(target);
+    // /v1/locations and /v1/warnings don't use location geohashes
+    if (isLocations || isWarnings || isWarningDetail) return await upstream(target);
 
     // For obs/forecasts: try variants (as-is, then shorten)
     const variants = buildVariants(target);
@@ -96,6 +98,7 @@ async function upstream(targetUrl) {
   const path = targetUrl.pathname || "";
   const ttl =
     path === "/v1/locations" ? 60 * 60 * 12 :
+    /^\/v1\/warnings\/?/i.test(path) ? 60 :
     /\/observations$/i.test(path) ? 60 * 5 :
     /\/forecasts\/hourly$/i.test(path) ? 60 * 10 :
     /\/forecasts\/3-hourly$/i.test(path) ? 60 * 30 :


### PR DESCRIPTION
Allow BOM API warnings endpoints in `bom-proxy` to enable fetching weather warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa0fc820-46e1-494b-a14b-5930866d2fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa0fc820-46e1-494b-a14b-5930866d2fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

