### PR TITLE
Weather warning image display

### DIFF
--- a/index.html
+++ b/index.html
@@ -960,6 +960,19 @@
     }
   }
 
+  const SAFE_IMAGE_DATA_RE = /^data:image\/(png|jpe?g|gif|webp);\s*base64,/i;
+  const BOM_IMAGE_BASE = 'https://www.bom.gov.au';
+
+  function normalizeImageSrc(raw){
+    const value = String(raw || '').trim();
+    if (!value) return '';
+    if (/^https?:/i.test(value)) return value;
+    if (value.startsWith('//')) return `https:${value}`;
+    if (SAFE_IMAGE_DATA_RE.test(value)) return value;
+    if (value.startsWith('/')) return `${BOM_IMAGE_BASE}${value}`;
+    return '';
+  }
+
   function sanitizeWarningHtml(raw){
     const tpl = document.createElement('template');
     tpl.innerHTML = String(raw || '');
@@ -995,9 +1008,16 @@
         if (allowSet && allowSet.has(name)) {
           if (tag === 'a' && name === 'href' && !/^https?:/i.test(value)) {
             el.removeAttribute(attr.name);
+            return;
           }
-          if (tag === 'img' && name === 'src' && !/^https?:/i.test(value)) {
-            el.removeAttribute(attr.name);
+          if (tag === 'img' && name === 'src') {
+            const normalized = normalizeImageSrc(value);
+            if (!normalized) {
+              el.removeAttribute(attr.name);
+              return;
+            }
+            if (normalized !== value) el.setAttribute('src', normalized);
+            return;
           }
           return;
         }


### PR DESCRIPTION
Allow `data:image/*;base64` sources and normalize image URLs to resolve images not displaying in weather warnings alerts.

The previous sanitizer was too strict, removing `src` attributes for images that were not explicitly `https:`, which prevented `data:` URIs and relative paths from rendering. This change introduces a normalization step to handle various valid image source formats from BOM, ensuring they display correctly while maintaining security.

---
<a href="https://cursor.com/background-agent?bcId=bc-165eafdb-a8c3-42a5-a351-111fbb71a7a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-165eafdb-a8c3-42a5-a351-111fbb71a7a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

