### PR TITLE
Weather alert modal width

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,6 +289,7 @@
     .modal.open{display:flex;}
     .modal-backdrop{position:absolute; inset:0; background:rgba(17,24,39,.38);}
     .modal-card{position:relative; width:min(720px, 100%); max-height:calc(100vh - 36px); background:var(--card); border:1px solid var(--line); border-radius:16px; box-shadow:0 20px 60px rgba(0,0,0,.18); overflow:hidden; display:flex; flex-direction:column;}
+    .modal-card.modal-wide{width:min(820px, 100%);}
     .modal-head{display:flex; align-items:center; justify-content:space-between; padding:14px 16px; border-bottom:1px solid var(--line)}
     .modal-title{margin:0; font-size:14px; font-weight:800;}
     .modal-close{border-radius:10px; padding:8px 10px;}
@@ -469,7 +470,7 @@
   <!-- Weather alert modal -->
   <div id="warningModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="warningTitle">
     <div class="modal-backdrop" data-close="1"></div>
-    <div class="modal-card">
+    <div class="modal-card modal-wide">
       <div class="modal-head">
         <div class="modal-title" id="warningTitle">Weather alerts</div>
         <button id="warningClose" class="icon-btn modal-close" type="button">Close</button>


### PR DESCRIPTION
Widen the weather alert modal to prevent tables from spreading over multiple lines, using a new `modal-wide` class to avoid affecting other modals.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5ce5c99-886e-4ab7-8a62-176660dbeb96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5ce5c99-886e-4ab7-8a62-176660dbeb96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

