### PR TITLE
Cancelled warnings dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,20 @@
     .row-top{display:block;}
     .park-name{display:flex; align-items:center; gap:8px; min-width:0;}
     .park-name b{flex:0 1 auto; min-width:0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;}
-    .badge{display:inline-flex; gap:6px; align-items:center; font-size:11px; padding:3px 8px; border-radius:999px; border:1px solid var(--line); color:var(--muted); white-space:nowrap; flex:0 0 auto}
+    .badge{
+      display:inline-flex;
+      gap:6px;
+      align-items:center;
+      font-size:11px;
+      padding:3px 8px;
+      border-radius:999px;
+      border:1px solid var(--line);
+      color:var(--muted);
+      white-space:nowrap;
+      flex:0 0 auto;
+      position:relative;
+      z-index:200;
+    }
     .badge.warning{border-color:rgba(217,119,6,.55); color:var(--warning)}
     .badge.danger{border-color:rgba(217,45,32,.55); color:var(--danger)}
     .weather-warning-btn{display:inline-flex; align-items:center; gap:6px; border-radius:999px; border:1px solid rgba(217,45,32,.55); background:var(--dangerFlashBg); color:var(--danger); padding:3px 8px; font-size:11px; font-weight:700; cursor:pointer; flex:0 0 auto}
@@ -176,7 +189,7 @@
       pointer-events:none;
       transform:translateY(4px);
       transition:opacity .15s ease, transform .15s ease;
-      z-index:20;
+      z-index:400;
       text-align:left;
     }
     .badge[data-tooltip]::before{
@@ -191,7 +204,7 @@
       pointer-events:none;
       transform:translateY(4px);
       transition:opacity .15s ease, transform .15s ease;
-      z-index:19;
+      z-index:399;
     }
     .badge[data-tooltip]:hover::after,
     .badge[data-tooltip]:focus-visible::after,

--- a/index.html
+++ b/index.html
@@ -243,6 +243,17 @@
     .current-col{min-width:88px;}
     .updated-col{min-width:88px;}
 
+    td.hour-cell,
+    td.current-col{
+      position:relative;
+    }
+    td.hour-cell:hover,
+    td.hour-cell:focus-within,
+    td.current-col:hover,
+    td.current-col:focus-within{
+      z-index:5;
+    }
+
     .dangerCell{color:var(--danger); font-weight:800;}
     .warningCell{color:var(--warning); font-weight:800;}
     .okCell{color:var(--ok); font-weight:700;}

--- a/index.html
+++ b/index.html
@@ -513,7 +513,7 @@
   const WARNING_TOOLTIP = 'Trees 13m or greater: Advise all park occupants to limit time spent in fall zones with no protection factors';
   const DANGER_TOOLTIP = 'Trees 6-12m: Advise all park occupants to limit time spent in fall zones with no protection factors. Trees 13m or greater: Create exclusion zone of tree hight +50% for fall zones with no protection factors';
   const IMPORTANT_WARNING_GROUPS = new Set(['major', 'moderate']);
-  const IMPORTANT_WARNING_LABEL = 'major and moderate alerts only';
+  const IMPORTANT_WARNING_LABEL = 'major and moderate alerts only (cancellations hidden)';
   const STATE_NAMES = {
     NSW: 'new south wales',
     ACT: 'australian capital territory',
@@ -1099,6 +1099,7 @@
   }
 
   const HEATWAVE_WARNING_RE = /\bheat\s*wave\b/i;
+  const CANCELLATION_WARNING_RE = /\bcancel(?:led|lation)\b/i;
 
   function isHeatwaveWarning(warn){
     const fields = [
@@ -1110,6 +1111,18 @@
       warn?.headline,
     ];
     return fields.some(v => typeof v === 'string' && HEATWAVE_WARNING_RE.test(v));
+  }
+
+  function isCancellationWarning(warn){
+    const fields = [
+      warn?.short_title,
+      warn?.title,
+      warn?.headline,
+      warn?.type_description,
+      warn?.warning_type,
+      warn?.type,
+    ];
+    return fields.some(v => typeof v === 'string' && CANCELLATION_WARNING_RE.test(v));
   }
 
   function filterHeatwaveWarnings(list){
@@ -1640,6 +1653,7 @@
   }
 
   function isImportantWarning(warn){
+    if (isCancellationWarning(warn)) return false;
     const group = String(warn?.warning_group_type || '').toLowerCase();
     if (!group) return true;
     return IMPORTANT_WARNING_GROUPS.has(group);
@@ -1967,6 +1981,8 @@
       heatwaveWarningsEnabled = false;
       assert('heatwave filter off', warningsForRow(warnRow).length === 1);
       heatwaveWarningsEnabled = prevHeatwave;
+
+      assert('cancellation hidden', isImportantWarning({ title: 'Cancellation of Flood Warning' }) === false);
 
       severityFilter = 'warning';
       assert('warning includes danger', filteredRows().length === 2);

--- a/index.html
+++ b/index.html
@@ -202,7 +202,13 @@
     }
 
     /* Cell hover tooltip (reuse badge tooltip style) */
-    .cell-tooltip[data-tooltip]{position:relative; cursor:help; display:inline-flex; align-items:baseline;}
+    .cell-tooltip[data-tooltip]{
+      position:relative;
+      cursor:help;
+      display:inline-flex;
+      align-items:baseline;
+      z-index:200;
+    }
     .cell-tooltip[data-tooltip]::after{
       content: attr(data-tooltip);
       position:absolute;
@@ -224,27 +230,11 @@
       pointer-events:none;
       transform:translateY(4px);
       transition:opacity .15s ease, transform .15s ease;
-      z-index:20;
+      z-index:300;
       text-align:left;
     }
-    .cell-tooltip[data-tooltip]::before{
-      content:"";
-      position:absolute;
-      left:12px;
-      top:100%;
-      border-width:0 6px 6px 6px;
-      border-style:solid;
-      border-color:transparent transparent var(--card) transparent;
-      opacity:0;
-      pointer-events:none;
-      transform:translateY(4px);
-      transition:opacity .15s ease, transform .15s ease;
-      z-index:19;
-    }
     .cell-tooltip[data-tooltip]:hover::after,
-    .cell-tooltip[data-tooltip]:focus-visible::after,
-    .cell-tooltip[data-tooltip]:hover::before,
-    .cell-tooltip[data-tooltip]:focus-visible::before{
+    .cell-tooltip[data-tooltip]:focus-visible::after{
       opacity:1;
       transform:translateY(0);
     }

--- a/index.html
+++ b/index.html
@@ -108,6 +108,9 @@
     th,td{padding:10px 12px; border-bottom:1px solid var(--line); font-size:13px; vertical-align:top}
     th{color:var(--muted); text-align:left; font-weight:600;}
     tr:last-child td{border-bottom:none;}
+    tbody tr{position:relative; z-index:0;}
+    tbody tr:hover,
+    tbody tr:focus-within{z-index:10;}
     .table-disclaimer{padding:10px 12px; border-top:1px solid var(--line);}
 
     .empty-cell{text-align:center;}


### PR DESCRIPTION
Filter out "Cancellation of..." weather alerts so they are treated as minor and not shown.

The user requested that these specific types of warnings, which indicate a previous warning has been cancelled, should not be displayed prominently as they are not active threats. This change ensures they are categorized as minor and hidden from the main dashboard view.

---
<a href="https://cursor.com/background-agent?bcId=bc-4219de5b-9ec6-44da-9bea-f815de931f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4219de5b-9ec6-44da-9bea-f815de931f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

